### PR TITLE
Add uninstall-global scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,7 @@ jobs:
             cp agents/explore.md               "$stage/agents/"
             cp THIRD_PARTY_LICENSES.md         "$stage/"
             cp scripts/install-global.sh       "$stage/scripts/"
+            cp scripts/uninstall-global.sh     "$stage/scripts/"
             chmod +x "$stage/scripts/"*.sh
 
             tar -czf "/tmp/$archive" -C "/tmp/stage-${platform}" context-king
@@ -154,6 +155,7 @@ jobs:
           cp agents/explore.md               "$win_stage/agents/"
           cp THIRD_PARTY_LICENSES.md         "$win_stage/"
           cp scripts/install-global.ps1      "$win_stage/scripts/"
+          cp scripts/uninstall-global.ps1    "$win_stage/scripts/"
 
           cd /tmp/stage-win && zip -r /tmp/context-king-windows.zip context-king
           echo "Built: context-king-windows.zip"
@@ -186,6 +188,20 @@ jobs:
 
             Or download the archive for your platform and run `bash scripts/install-global.sh` from within it.
 
+            ## Uninstall
+
+            **Mac / Linux:**
+            ```bash
+            curl -fsSL https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.sh | bash
+            ```
+
+            **Windows (PowerShell 7+):**
+            ```powershell
+            irm https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.ps1 | iex
+            ```
+
+            Preview first with `--dry-run` (PowerShell: `-DryRun`). Per-repo files from `ck init` are left untouched.
+
             ## Platform archives
             | File | Platform |
             |------|----------|
@@ -207,3 +223,5 @@ jobs:
             /tmp/binaries/ck-win-x64.exe
             scripts/install-global.sh
             scripts/install-global.ps1
+            scripts/uninstall-global.sh
+            scripts/uninstall-global.ps1

--- a/README.md
+++ b/README.md
@@ -235,6 +235,31 @@ Windows equivalents:
 
 ---
 
+## Uninstall
+
+To reverse the global install, run the uninstaller from a cloned repo:
+
+**Mac / Linux:**
+```bash
+bash scripts/uninstall-global.sh
+```
+
+**Windows:**
+```powershell
+pwsh scripts/uninstall-global.ps1
+```
+
+This removes the `~/.ck` tree (binary + model), strips `~/.ck/bin` from your PATH, deletes the CK skills/hooks/rules from `~/.claude/`, `~/.codex/`, `~/.config/opencode/`, and `~/.agents/`, and removes only the CK entries from each client's config files (`settings.json`, `hooks.json`, `opencode.json(c)`, Codex `AGENTS.md` / `config.toml`) — all other content is left intact.
+
+Preview without changing anything with `--dry-run` (PowerShell: `-DryRun`). The same skip flags as the installer are supported (`--no-path`, `--no-claude`, `--no-codex`, `--no-opencode`, `--no-agents`, and the `--*-home` overrides).
+
+**Per-repo files** created by `ck init` are **not** removed (they may be git-tracked). To clean a repository manually:
+```bash
+rm -rf .ck-index .ck-knowledge .ck.json
+```
+
+---
+
 ## Enforcement
 
 Context King enforces the navigation workflow through rules, hooks, and skill instructions. The mechanism varies by CLI tool.

--- a/README.md
+++ b/README.md
@@ -237,21 +237,26 @@ Windows equivalents:
 
 ## Uninstall
 
-To reverse the global install, run the uninstaller from a cloned repo:
+To reverse the global install, run the uninstaller the same way you installed:
 
 **Mac / Linux:**
 ```bash
-bash scripts/uninstall-global.sh
+curl -fsSL https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.sh | bash
 ```
 
 **Windows:**
 ```powershell
-pwsh scripts/uninstall-global.ps1
+irm https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.ps1 | iex
 ```
 
 This removes the `~/.ck` tree (binary + model), strips `~/.ck/bin` from your PATH, deletes the CK skills/hooks/rules from `~/.claude/`, `~/.codex/`, `~/.config/opencode/`, and `~/.agents/`, and removes only the CK entries from each client's config files (`settings.json`, `hooks.json`, `opencode.json(c)`, Codex `AGENTS.md` / `config.toml`) — all other content is left intact.
 
-Preview without changing anything with `--dry-run` (PowerShell: `-DryRun`). The same skip flags as the installer are supported (`--no-path`, `--no-claude`, `--no-codex`, `--no-opencode`, `--no-agents`, and the `--*-home` overrides).
+To preview without changing anything, or to use the skip flags, download and run the script directly:
+```bash
+curl -fsSL https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.sh -o uninstall-global.sh
+bash uninstall-global.sh --dry-run
+```
+Supported flags mirror the installer: `--dry-run` (PowerShell: `-DryRun`), `--no-path`, `--no-claude`, `--no-codex`, `--no-opencode`, `--no-agents`, and the `--*-home` overrides.
 
 **Per-repo files** created by `ck init` are **not** removed (they may be git-tracked). To clean a repository manually:
 ```bash

--- a/scripts/test-uninstall-global-codex-fallback.sh
+++ b/scripts/test-uninstall-global-codex-fallback.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test: uninstall-global.sh must only remove the exact
+# project_doc_fallback_filenames line the installer writes, and must leave a
+# user-owned value (which the installer deliberately skips) untouched.
+
+tmp_home="$(mktemp -d)"
+cleanup() { rm -rf "$tmp_home"; }
+trap cleanup EXIT
+
+codex_home="$tmp_home/codex"
+mkdir -p "$codex_home"
+cfg="$codex_home/config.toml"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+run_uninstall() {
+  bash scripts/uninstall-global.sh \
+    --codex-home "$codex_home" \
+    --no-path --no-claude --no-opencode --no-agents >/dev/null 2>&1
+}
+
+# Case 1: CK-installed line is removed.
+printf 'model = "gpt-5"\nproject_doc_fallback_filenames = ["ck-code-search-protocol.md"]\n' > "$cfg"
+run_uninstall
+if grep -qF 'project_doc_fallback_filenames' "$cfg"; then
+  fail "CK-installed fallback line was not removed"
+fi
+grep -qF 'model = "gpt-5"' "$cfg" || fail "unrelated config was lost"
+
+# Case 2: user-owned single-line value is preserved (installer would have skipped it).
+printf 'project_doc_fallback_filenames = ["AGENTS.md", "ck-code-search-protocol.md"]\n' > "$cfg"
+run_uninstall
+grep -qF 'project_doc_fallback_filenames = ["AGENTS.md", "ck-code-search-protocol.md"]' "$cfg" \
+  || fail "user-owned single-line value was modified"
+
+# Case 3: user-owned multi-line array is preserved intact (no partial deletion / dangling ]).
+cat > "$cfg" <<'TOML'
+project_doc_fallback_filenames = [
+  "AGENTS.md",
+  "ck-code-search-protocol.md",
+]
+TOML
+run_uninstall
+expected=$(cat <<'TOML'
+project_doc_fallback_filenames = [
+  "AGENTS.md",
+  "ck-code-search-protocol.md",
+]
+TOML
+)
+if [ "$(cat "$cfg")" != "$expected" ]; then
+  fail "user-owned multi-line array was corrupted"
+fi
+
+echo "PASS: uninstall removes only the CK-written fallback line"

--- a/scripts/uninstall-global.ps1
+++ b/scripts/uninstall-global.ps1
@@ -194,15 +194,19 @@ if (-not $NoCodex) {
     }
   }
 
-  # Remove the project_doc_fallback_filenames line from config.toml.
+  # Remove the project_doc_fallback_filenames line from config.toml. Match the
+  # exact literal the installer writes (symmetric with the install side) so we
+  # never touch a user-owned value the installer deliberately skipped, and never
+  # half-delete a multi-line TOML array.
   $CodexConfigToml = "$CodexHome\config.toml"
+  $CodexFallbackLine = 'project_doc_fallback_filenames = ["ck-code-search-protocol.md"]'
   if (Test-Path $CodexConfigToml) {
-    $tomlContent = Get-Content $CodexConfigToml -Raw -ErrorAction SilentlyContinue
-    if ($tomlContent -match 'project_doc_fallback_filenames') {
+    $tomlLines = @(Get-Content $CodexConfigToml -ErrorAction SilentlyContinue)
+    if ($tomlLines | Where-Object { $_.Trim() -eq $CodexFallbackLine }) {
       if ($DryRun) {
         Write-Host "  [dry-run] remove project_doc_fallback_filenames from $CodexConfigToml"
       } else {
-        $kept = @(Get-Content $CodexConfigToml | Where-Object { $_ -notmatch 'project_doc_fallback_filenames' })
+        $kept = @($tomlLines | Where-Object { $_.Trim() -ne $CodexFallbackLine })
         Set-Content -LiteralPath $CodexConfigToml -Value $kept -Encoding UTF8
         Write-Ok "Removed project_doc_fallback_filenames from $CodexConfigToml"
       }

--- a/scripts/uninstall-global.ps1
+++ b/scripts/uninstall-global.ps1
@@ -6,6 +6,7 @@
 # .ck-index\) are NOT touched — they may be git-tracked; remove them manually.
 #
 # Usage:
+#   iex (iwr 'https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.ps1').Content
 #   .\scripts\uninstall-global.ps1
 #   .\scripts\uninstall-global.ps1 -DryRun
 #   .\scripts\uninstall-global.ps1 -CkHome "$env:USERPROFILE\.ck" -NoClaude

--- a/scripts/uninstall-global.ps1
+++ b/scripts/uninstall-global.ps1
@@ -1,0 +1,329 @@
+# uninstall-global.ps1 — Context King global user uninstaller (Windows/PowerShell).
+#
+# Reverses scripts/install-global.ps1: removes the ck binary, embedding model,
+# skills, hooks, rules/protocol files, and the CK entries it registered in each
+# client's config. Per-repo files created by `ck init` (.ck.json, .ck-knowledge\,
+# .ck-index\) are NOT touched — they may be git-tracked; remove them manually.
+#
+# Usage:
+#   .\scripts\uninstall-global.ps1
+#   .\scripts\uninstall-global.ps1 -DryRun
+#   .\scripts\uninstall-global.ps1 -CkHome "$env:USERPROFILE\.ck" -NoClaude
+#
+# Parameters:
+#   -CkHome <path>       Installation root (default: $env:USERPROFILE\.ck)
+#   -ClaudeHome <path>   Claude Code config dir (default: $env:USERPROFILE\.claude)
+#   -CodexHome <path>    Codex config dir (default: $env:USERPROFILE\.codex)
+#   -OpenCodeHome <path> OpenCode config dir (default: $env:APPDATA\opencode)
+#   -AgentsHome <path>   Agents skills dir (default: $env:USERPROFILE\.agents)
+#   -DryRun              Print every action without performing it
+#   -NoPath              Skip PATH cleanup
+#   -NoClaude            Skip Claude Code cleanup
+#   -NoCodex             Skip Codex cleanup
+#   -NoOpenCode          Skip OpenCode cleanup
+#   -NoAgents            Skip Agents cleanup
+
+param(
+  [string]$CkHome      = "$env:USERPROFILE\.ck",
+  [string]$ClaudeHome  = "$env:USERPROFILE\.claude",
+  [string]$CodexHome   = "$env:USERPROFILE\.codex",
+  [string]$OpenCodeHome = "$env:APPDATA\opencode",
+  [string]$AgentsHome  = "$env:USERPROFILE\.agents",
+  [switch]$DryRun,
+  [switch]$NoPath,
+  [switch]$NoClaude,
+  [switch]$NoCodex,
+  [switch]$NoOpenCode,
+  [switch]$NoAgents
+)
+
+$ErrorActionPreference = "Stop"
+
+$CkBinDir = "$CkHome\bin"
+$LegacyOpenCodeHome = "$env:USERPROFILE\.opencode"
+
+function Write-Ok($msg)   { Write-Host "  OK $msg" }
+function Write-Info($msg) { Write-Host $msg }
+
+# Remove a single path (file or directory). No-op if absent.
+function Remove-Path($p) {
+  if (-not (Test-Path $p)) { return }
+  if ($DryRun) {
+    Write-Host "  [dry-run] remove $p"
+  } else {
+    Remove-Item $p -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Ok "Removed $p"
+  }
+}
+
+function Remove-CkSkills($SkillsRoot) {
+  if (-not (Test-Path $SkillsRoot)) { return }
+  if ($DryRun) {
+    if (Test-Path "$SkillsRoot\ck") { Write-Host "  [dry-run] remove $SkillsRoot\ck" }
+    Get-ChildItem $SkillsRoot -Directory -Filter "ck-*" -ErrorAction SilentlyContinue |
+      ForEach-Object { Write-Host "  [dry-run] remove $($_.FullName)" }
+    return
+  }
+  Remove-Item "$SkillsRoot\ck" -Recurse -Force -ErrorAction SilentlyContinue
+  Get-ChildItem $SkillsRoot -Directory -Filter "ck-*" -ErrorAction SilentlyContinue |
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Remove-CkHooks($HooksRoot) {
+  if (-not (Test-Path $HooksRoot)) { return }
+  $patterns = @("ck-*.ps1", "ck-*.sh", "agent-usage-guard.ps1", "agent-usage-guard.sh")
+  foreach ($pat in $patterns) {
+    Get-ChildItem $HooksRoot -File -Filter $pat -ErrorAction SilentlyContinue | ForEach-Object {
+      if ($DryRun) { Write-Host "  [dry-run] remove $($_.FullName)" }
+      else { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
+    }
+  }
+}
+
+Write-Info "Uninstalling Context King (global)"
+if ($DryRun) { Write-Info "  (dry run — no changes will be made)" }
+Write-Info ""
+
+# ── Remove binary + models (whole .ck tree) ──────────────────────────────────
+Write-Info "── Binary & models ($CkHome\) ────────────────────────────────────────"
+Remove-Path $CkHome
+Write-Info ""
+
+# ── Remove .ck\bin from user PATH ────────────────────────────────────────────
+if (-not $NoPath) {
+  Write-Info "── PATH cleanup ──────────────────────────────────────────────────────"
+  $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+  if ($UserPath -and ($UserPath -like "*$CkBinDir*")) {
+    $newParts = @($UserPath -split ';' | Where-Object { $_ -and ($_ -ne $CkBinDir) })
+    $newPath = $newParts -join ';'
+    if ($DryRun) {
+      Write-Host "  [dry-run] remove $CkBinDir from user PATH"
+    } else {
+      [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+      Write-Ok "Removed $CkBinDir from user PATH"
+    }
+  }
+  Write-Info ""
+}
+
+# ── Claude Code ────────────────────────────────────────────────────────────────
+if (-not $NoClaude) {
+  Write-Info "── Claude Code ($ClaudeHome\) ──────────────────────────────────────────"
+  Remove-CkSkills "$ClaudeHome\skills"
+  Remove-CkHooks  "$ClaudeHome\hooks"
+  Remove-Path "$ClaudeHome\rules\ck-code-search-protocol.md"
+  Remove-Path "$ClaudeHome\models\bge-small-en-v1.5"
+  if (-not $DryRun) { Write-Ok "Skills and hooks removed" }
+
+  $Settings = "$ClaudeHome\settings.json"
+  if (Test-Path $Settings) {
+    if ($DryRun) {
+      Write-Host "  [dry-run] remove CK hook + permission entries from $Settings"
+    } else {
+      try {
+        $cfg = Get-Content -LiteralPath $Settings -Raw | ConvertFrom-Json -AsHashtable
+        if (-not $cfg) { $cfg = @{} }
+
+        if ($cfg.ContainsKey('permissions') -and ($cfg['permissions'] -is [hashtable])) {
+          $permissions = $cfg['permissions']
+          if ($permissions.ContainsKey('allowedTools')) {
+            $permissions['allowedTools'] = @($permissions['allowedTools'] | Where-Object {
+              $_ -and ($_ -notmatch 'ck/ck|ck\.cmd|"ck |Bash\(ck ')
+            })
+          }
+          $cfg['permissions'] = $permissions
+        }
+
+        if ($cfg.ContainsKey('hooks') -and ($cfg['hooks'] -is [hashtable])) {
+          $hooks = $cfg['hooks']
+          $eventPatterns = @{
+            PreToolUse    = 'ck-bash-guard|ck-read-guard|ck-search-guard'
+            SubagentStart = 'agent-usage-guard'
+            PostToolUse   = 'ck-scope-hint'
+            SessionStart  = 'ck-update-check'
+            Stop          = 'ck-postsession'
+          }
+          foreach ($event in @($hooks.Keys)) {
+            if (-not $eventPatterns.ContainsKey($event)) { continue }
+            $pat = $eventPatterns[$event]
+            $cleaned = @()
+            foreach ($entry in @($hooks[$event])) {
+              $entryHooks = @($entry['hooks'] | Where-Object { -not ([string]($_['command']) -match $pat) })
+              if ($entryHooks.Count -gt 0) {
+                $entry['hooks'] = $entryHooks
+                $cleaned += $entry
+              }
+            }
+            $hooks[$event] = $cleaned
+          }
+          $cfg['hooks'] = $hooks
+        }
+
+        $cfg | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $Settings -Encoding UTF8
+        Write-Ok "Removed CK hook and permission entries from $Settings"
+      } catch {
+        Write-Warning "Could not update $Settings automatically. Remove the Bash(ck *) permission and ck-* hook entries manually."
+      }
+    }
+  }
+  Write-Info ""
+}
+
+# ── Codex ──────────────────────────────────────────────────────────────────────
+if (-not $NoCodex) {
+  Write-Info "── Codex ($CodexHome\) ─────────────────────────────────────────────────"
+  Remove-CkSkills "$CodexHome\skills"
+  Remove-CkHooks  "$CodexHome\hooks"
+  Remove-Path "$CodexHome\ck-code-search-protocol.md"
+  if (-not $DryRun) { Write-Ok "Skills, hooks and protocol removed" }
+
+  # Remove the CK navigation section appended to AGENTS.md (sentinel → EOF).
+  $CodexAgentsMd = "$CodexHome\AGENTS.md"
+  if (Test-Path $CodexAgentsMd) {
+    $agentsContent = Get-Content $CodexAgentsMd -Raw -ErrorAction SilentlyContinue
+    if ($agentsContent -match [regex]::Escape('## CODE NAVIGATION (Context King)')) {
+      if ($DryRun) {
+        Write-Host "  [dry-run] remove CK navigation section from $CodexAgentsMd"
+      } else {
+        $idx = $agentsContent.IndexOf('## CODE NAVIGATION (Context King)')
+        $kept = $agentsContent.Substring(0, $idx).TrimEnd("`r", "`n", " ", "`t")
+        Set-Content -LiteralPath $CodexAgentsMd -Value $kept -Encoding UTF8 -NoNewline
+        Write-Ok "Removed CK navigation section from $CodexAgentsMd"
+      }
+    }
+  }
+
+  # Remove the project_doc_fallback_filenames line from config.toml.
+  $CodexConfigToml = "$CodexHome\config.toml"
+  if (Test-Path $CodexConfigToml) {
+    $tomlContent = Get-Content $CodexConfigToml -Raw -ErrorAction SilentlyContinue
+    if ($tomlContent -match 'project_doc_fallback_filenames') {
+      if ($DryRun) {
+        Write-Host "  [dry-run] remove project_doc_fallback_filenames from $CodexConfigToml"
+      } else {
+        $kept = @(Get-Content $CodexConfigToml | Where-Object { $_ -notmatch 'project_doc_fallback_filenames' })
+        Set-Content -LiteralPath $CodexConfigToml -Value $kept -Encoding UTF8
+        Write-Ok "Removed project_doc_fallback_filenames from $CodexConfigToml"
+      }
+    }
+  }
+
+  $CodexHooksJson = "$CodexHome\hooks.json"
+  if (Test-Path $CodexHooksJson) {
+    if ($DryRun) {
+      Write-Host "  [dry-run] remove CK hook entries from $CodexHooksJson"
+    } else {
+      try {
+        $cfg = Get-Content -LiteralPath $CodexHooksJson -Raw | ConvertFrom-Json -AsHashtable
+        if ($cfg -and $cfg.ContainsKey('hooks') -and ($cfg['hooks'] -is [hashtable])) {
+          $hooks = $cfg['hooks']
+          $eventPatterns = @{
+            PreToolUse   = 'ck-bash-guard|ck-read-guard|ck-search-guard'
+            PostToolUse  = 'ck-scope-hint'
+            SessionStart = 'ck-update-check'
+            Stop         = 'ck-postsession'
+          }
+          foreach ($event in @($hooks.Keys)) {
+            if (-not $eventPatterns.ContainsKey($event)) { continue }
+            $pat = $eventPatterns[$event]
+            $cleaned = @()
+            foreach ($entry in @($hooks[$event])) {
+              $entryHooks = @($entry['hooks'] | Where-Object { -not ([string]($_['command']) -match $pat) })
+              if ($entryHooks.Count -gt 0) {
+                $entry['hooks'] = $entryHooks
+                $cleaned += $entry
+              }
+            }
+            $hooks[$event] = $cleaned
+          }
+          $cfg['hooks'] = $hooks
+          $cfg | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $CodexHooksJson -Encoding UTF8
+          Write-Ok "Removed CK hook entries from $CodexHooksJson"
+        }
+      } catch {
+        Write-Warning "Could not update $CodexHooksJson automatically. Remove the ck-* hook entries manually."
+      }
+    }
+  }
+  Write-Info ""
+}
+
+# ── OpenCode ───────────────────────────────────────────────────────────────────
+if (-not $NoOpenCode) {
+  Write-Info "── OpenCode ($OpenCodeHome\) ──────────────────────────────────────────"
+  Remove-CkSkills "$OpenCodeHome\skills"
+  Remove-Path "$OpenCodeHome\plugins\ck-guards.ts"
+  Remove-Path "$LegacyOpenCodeHome\plugin\ck-guards.ts"
+  Remove-Path "$OpenCodeHome\agents\explore.md"
+  Remove-Path "$OpenCodeHome\ck-code-search-protocol.md"
+  if (-not $DryRun) { Write-Ok "Skills, plugin, agent and protocol removed" }
+
+  # Determine which OpenCode config file the installer wrote to.
+  $OpenCodeCfg = ""
+  if (Test-Path "$OpenCodeHome\opencode.jsonc") {
+    $OpenCodeCfg = "$OpenCodeHome\opencode.jsonc"
+  } elseif (Test-Path "$OpenCodeHome\opencode.json") {
+    $OpenCodeCfg = "$OpenCodeHome\opencode.json"
+  }
+
+  if ($OpenCodeCfg) {
+    if ($DryRun) {
+      Write-Host "  [dry-run] remove CK plugin + instructions entries from $OpenCodeCfg"
+    } else {
+      try {
+        $rawCfg = Get-Content -LiteralPath $OpenCodeCfg -Raw
+        if ($OpenCodeCfg.ToLower().EndsWith('.jsonc')) {
+          # Keep JSONC comments by patching only target arrays in-place.
+          function Remove-JsoncArrayEntry {
+            param([string]$Text, [string]$Key, [string]$Value)
+            $pattern = '(?s)("' + [regex]::Escape($Key) + '"\s*:\s*\[)(.*?)(\])'
+            $m = [regex]::Match($Text, $pattern)
+            if (-not $m.Success) { return $Text }
+            $body = $m.Groups[2].Value
+            $quoted = [regex]::Escape($Value)
+            $newBody = [regex]::Replace($body, '\s*"' + $quoted + '"\s*,?', '', 1)
+            $newBody = [regex]::Replace($newBody, ',(\s*)$', '$1')
+            $newBody = [regex]::Replace($newBody, '^(\s*),', '$1')
+            return $Text.Substring(0, $m.Index) + $m.Groups[1].Value + $newBody + $m.Groups[3].Value + $Text.Substring($m.Index + $m.Length)
+          }
+          $rawCfg = Remove-JsoncArrayEntry -Text $rawCfg -Key 'plugin' -Value './plugins/ck-guards.ts'
+          $rawCfg = Remove-JsoncArrayEntry -Text $rawCfg -Key 'instructions' -Value './ck-code-search-protocol.md'
+          Set-Content -LiteralPath $OpenCodeCfg -Value $rawCfg -Encoding UTF8 -NoNewline
+        } else {
+          $cfg = $rawCfg | ConvertFrom-Json -AsHashtable
+          if ($cfg.ContainsKey('plugin')) {
+            $cfg['plugin'] = @($cfg['plugin'] | Where-Object { $_ -ne './plugins/ck-guards.ts' })
+          }
+          if ($cfg.ContainsKey('instructions')) {
+            $cfg['instructions'] = @($cfg['instructions'] | Where-Object { $_ -ne './ck-code-search-protocol.md' })
+          }
+          $cfg | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $OpenCodeCfg -Encoding UTF8
+        }
+        Write-Ok "Removed CK plugin and instructions entries from $OpenCodeCfg"
+      } catch {
+        Write-Warning "Could not update $OpenCodeCfg automatically. Remove './plugins/ck-guards.ts' from plugin[] and './ck-code-search-protocol.md' from instructions[] manually."
+      }
+    }
+  }
+  Write-Info ""
+}
+
+# ── Agent Skills ───────────────────────────────────────────────────────────────
+if (-not $NoAgents) {
+  Write-Info "── Agent Skills ($AgentsHome\skills\) ────────────────────────────────"
+  Remove-CkSkills "$AgentsHome\skills"
+  if (-not $DryRun) { Write-Ok "Skills removed" }
+  Write-Info ""
+}
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+if ($DryRun) {
+  Write-Info "Dry run complete — no changes were made."
+} else {
+  Write-Info "Context King uninstalled globally."
+}
+Write-Info ""
+Write-Info "Per-repo files created by 'ck init' are NOT removed (they may be git-tracked)."
+Write-Info "To remove them from a repository:"
+Write-Info "  Remove-Item -Recurse -Force .ck-index, .ck-knowledge, .ck.json"
+Write-Info "Also remove .ck-index\ from that repo's .gitignore if you added it."

--- a/scripts/uninstall-global.sh
+++ b/scripts/uninstall-global.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# uninstall-global.sh — Context King global user uninstaller.
+#
+# This script targets macOS/Linux shell environments. For Windows, use
+# scripts/uninstall-global.ps1 (PowerShell).
+#
+# Reverses scripts/install-global.sh: removes the ck binary, embedding model,
+# skills, hooks, rules/protocol files, and the CK entries it registered in each
+# client's config. Per-repo files created by `ck init` (.ck.json, .ck-knowledge/,
+# .ck-index/) are NOT touched — they may be git-tracked; remove them manually.
+#
+# ── Run from a cloned repo ──────────────────────────────────────────────────────
+#   bash scripts/uninstall-global.sh
+#
+# ── Preview without changing anything ───────────────────────────────────────────
+#   bash scripts/uninstall-global.sh --dry-run
+#
+# ── Options ───────────────────────────────────────────────────────────────────
+#   --ck-home <path>    Override installation root (default: ~/.ck)
+#   --claude-home <p>   Override Claude Code config dir (default: ~/.claude)
+#   --codex-home <p>    Override Codex config dir (default: ~/.codex)
+#   --opencode-home <p> Override OpenCode config dir (default: ~/.config/opencode)
+#   --agents-home <p>   Override Agents skills dir (default: ~/.agents)
+#   --dry-run           Print every action without performing it
+#   --no-path           Skip PATH cleanup in shell config files
+#   --no-claude         Skip Claude Code cleanup
+#   --no-codex          Skip Codex cleanup
+#   --no-opencode       Skip OpenCode cleanup
+#   --no-agents         Skip Agents cleanup
+#
+# What this script removes:
+#   ~/.ck/                               binary + embedding model (whole tree)
+#   ~/.claude/skills/ck*/                Claude Code skills
+#   ~/.claude/hooks/ck-*.sh|.ps1         Claude Code hooks
+#   ~/.claude/rules/ck-code-search-protocol.md
+#   ~/.claude/models/bge-small-en-v1.5/  copied embedding model
+#   ~/.claude/settings.json              CK hook + permission entries (entries only)
+#   ~/.codex/skills/ck*/                 Codex skills
+#   ~/.codex/hooks/ck-*.sh               Codex hooks
+#   ~/.codex/hooks.json                  CK hook entries (entries only)
+#   ~/.codex/ck-code-search-protocol.md  Codex protocol reference
+#   ~/.codex/AGENTS.md                   CK navigation section (section only)
+#   ~/.codex/config.toml                 project_doc_fallback_filenames line
+#   ~/.config/opencode/skills/ck*/       OpenCode skills
+#   ~/.config/opencode/plugins/ck-guards.ts
+#   ~/.opencode/plugin/ck-guards.ts      Legacy OpenCode plugin path
+#   ~/.config/opencode/agents/explore.md
+#   ~/.config/opencode/ck-code-search-protocol.md
+#   ~/.config/opencode/opencode.json(c)  CK plugin + instructions entries (entries only)
+#   ~/.agents/skills/ck*/                Generic Agent Skills
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+CK_HOME="${CK_HOME:-$HOME/.ck}"
+CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
+CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+OPENCODE_HOME="${OPENCODE_HOME:-$HOME/.config/opencode}"
+LEGACY_OPENCODE_HOME="${LEGACY_OPENCODE_HOME:-$HOME/.opencode}"
+AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
+DRY_RUN=false
+MODIFY_PATH=true
+DO_CLAUDE=true
+DO_CODEX=true
+DO_OPENCODE=true
+DO_AGENTS=true
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --ck-home)      CK_HOME="$2";      shift 2 ;;
+    --claude-home)  CLAUDE_HOME="$2";  shift 2 ;;
+    --codex-home)   CODEX_HOME="$2";   shift 2 ;;
+    --opencode-home) OPENCODE_HOME="$2"; shift 2 ;;
+    --agents-home)  AGENTS_HOME="$2";  shift 2 ;;
+    --dry-run)      DRY_RUN=true;      shift ;;
+    --no-path)      MODIFY_PATH=false; shift ;;
+    --no-claude)    DO_CLAUDE=false;   shift ;;
+    --no-codex)     DO_CODEX=false;    shift ;;
+    --no-opencode)  DO_OPENCODE=false; shift ;;
+    --no-agents)    DO_AGENTS=false;   shift ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -34
+      exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+CK_BIN_DIR="$CK_HOME/bin"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+info() { echo "$*"; }
+ok()   { echo "  ✓ $*"; }
+
+# Remove a single path (file or directory). No-op if absent.
+rm_path() {
+  local target="$1"
+  [ -e "$target" ] || return 0
+  if [ "$DRY_RUN" = true ]; then
+    echo "  [dry-run] rm -rf $target"
+  else
+    rm -rf "$target"
+    ok "Removed $target"
+  fi
+}
+
+purge_ck_skills() {
+  local root="$1"
+  [ -d "$root" ] || return 0
+  if [ "$DRY_RUN" = true ]; then
+    [ -d "$root/ck" ] && echo "  [dry-run] rm -rf $root/ck"
+    for d in "$root"/ck-*; do [ -d "$d" ] && echo "  [dry-run] rm -rf $d"; done
+    return 0
+  fi
+  rm -rf "$root/ck" 2>/dev/null || true
+  for d in "$root"/ck-*; do [ -d "$d" ] && rm -rf "$d"; done 2>/dev/null || true
+}
+
+purge_ck_hooks() {
+  local root="$1"
+  [ -d "$root" ] || return 0
+  if [ "$DRY_RUN" = true ]; then
+    ls "$root"/ck-*.sh "$root"/ck-*.ps1 "$root"/agent-usage-guard.sh "$root"/agent-usage-guard.ps1 2>/dev/null \
+      | while IFS= read -r f; do echo "  [dry-run] rm -f $f"; done
+    return 0
+  fi
+  rm -f "$root"/ck-*.sh "$root"/ck-*.ps1 "$root"/agent-usage-guard.sh "$root"/agent-usage-guard.ps1 2>/dev/null || true
+}
+
+info "Uninstalling Context King (global)"
+if [ "$DRY_RUN" = true ]; then info "  (dry run — no changes will be made)"; fi
+info ""
+
+# ── Remove binary + models (whole ~/.ck tree) ────────────────────────────────
+info "── Binary & models (~/.ck) ───────────────────────────────────────────────"
+rm_path "$CK_HOME"
+info ""
+
+# ── Remove ~/.ck/bin from PATH in shell config files ──────────────────────────
+if [ "$MODIFY_PATH" = true ]; then
+  info "── PATH cleanup ──────────────────────────────────────────────────────────"
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+    if [ -f "$rc" ] && grep -qF "$CK_BIN_DIR" "$rc" 2>/dev/null; then
+      if [ "$DRY_RUN" = true ]; then
+        echo "  [dry-run] strip Context King PATH lines from $rc"
+      else
+        tmp="$(mktemp)"
+        # Drop the "# Context King" marker line and any line referencing CK_BIN_DIR.
+        grep -vF "$CK_BIN_DIR" "$rc" | grep -vxF "# Context King" > "$tmp" || true
+        mv "$tmp" "$rc"
+        ok "Removed $CK_BIN_DIR from PATH in $rc"
+      fi
+    fi
+  done
+  info ""
+fi
+
+# ── Claude Code (~/.claude/) ──────────────────────────────────────────────────
+if [ "$DO_CLAUDE" = true ]; then
+  info "── Claude Code (~/.claude/) ──────────────────────────────────────────────"
+  purge_ck_skills "$CLAUDE_HOME/skills"
+  purge_ck_hooks  "$CLAUDE_HOME/hooks"
+  rm_path "$CLAUDE_HOME/rules/ck-code-search-protocol.md"
+  rm_path "$CLAUDE_HOME/models/bge-small-en-v1.5"
+  [ "$DRY_RUN" = true ] || ok "Skills and hooks removed"
+
+  SETTINGS="$CLAUDE_HOME/settings.json"
+  if [ -f "$SETTINGS" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      if [ "$DRY_RUN" = true ]; then
+        echo "  [dry-run] remove CK hook + permission entries from $SETTINGS"
+      else
+        jq '
+          .permissions.allowedTools = [(.permissions.allowedTools // [])[] | select(
+            test("ck/ck|ck\\.cmd|\"ck |Bash\\(ck ") | not
+          )] |
+          .hooks.PreToolUse    = [(.hooks.PreToolUse    // [])[] | .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-bash-guard|ck-read-guard|ck-search-guard") | not)] | select((.hooks | length) > 0)] |
+          .hooks.SubagentStart = [(.hooks.SubagentStart // [])[] | .hooks = [(.hooks // [])[]? | select((.command // "") | test("agent-usage-guard")            | not)] | select((.hooks | length) > 0)] |
+          .hooks.PostToolUse   = [(.hooks.PostToolUse   // [])[] | .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-scope-hint")                | not)] | select((.hooks | length) > 0)] |
+          .hooks.SessionStart  = [(.hooks.SessionStart  // [])[] | .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-update-check")              | not)] | select((.hooks | length) > 0)] |
+          .hooks.Stop          = [(.hooks.Stop          // [])[] | .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-postsession")               | not)] | select((.hooks | length) > 0)]
+        ' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+        ok "Removed CK hook and permission entries from $SETTINGS"
+      fi
+    else
+      echo "  WARNING: jq not found — CK entries in $SETTINGS not removed."
+      echo "  Manually delete the Bash(ck *) permission and the ck-*/agent-usage-guard hook entries."
+    fi
+  fi
+  info ""
+fi
+
+# ── Codex (~/.codex/) ─────────────────────────────────────────────────────────
+if [ "$DO_CODEX" = true ]; then
+  info "── Codex (~/.codex/) ─────────────────────────────────────────────────────"
+  purge_ck_skills "$CODEX_HOME/skills"
+  purge_ck_hooks  "$CODEX_HOME/hooks"
+  rm_path "$CODEX_HOME/ck-code-search-protocol.md"
+  [ "$DRY_RUN" = true ] || ok "Skills, hooks and protocol removed"
+
+  # Remove the CK navigation section appended to AGENTS.md (sentinel → EOF),
+  # then trim any trailing blank lines left behind.
+  AGENTS_MD="$CODEX_HOME/AGENTS.md"
+  if [ -f "$AGENTS_MD" ] && grep -qF '## CODE NAVIGATION (Context King)' "$AGENTS_MD" 2>/dev/null; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "  [dry-run] remove CK navigation section from $AGENTS_MD"
+    else
+      # Delete from the sentinel to EOF; command substitution strips the
+      # trailing blank lines the section left behind (portable, no BSD-sed quirks).
+      kept="$(sed '/## CODE NAVIGATION (Context King)/,$d' "$AGENTS_MD")"
+      if [ -n "$kept" ]; then
+        printf '%s\n' "$kept" > "$AGENTS_MD"
+      else
+        : > "$AGENTS_MD"
+      fi
+      ok "Removed CK navigation section from $AGENTS_MD"
+    fi
+  fi
+
+  # Remove the project_doc_fallback_filenames line from config.toml.
+  CODEX_CONFIG="$CODEX_HOME/config.toml"
+  if [ -f "$CODEX_CONFIG" ] && grep -qF 'project_doc_fallback_filenames' "$CODEX_CONFIG" 2>/dev/null; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "  [dry-run] remove project_doc_fallback_filenames from $CODEX_CONFIG"
+    else
+      tmp="$(mktemp)"
+      grep -v 'project_doc_fallback_filenames' "$CODEX_CONFIG" > "$tmp" || true
+      mv "$tmp" "$CODEX_CONFIG"
+      ok "Removed project_doc_fallback_filenames from $CODEX_CONFIG"
+    fi
+  fi
+
+  HOOKS_JSON="$CODEX_HOME/hooks.json"
+  if [ -f "$HOOKS_JSON" ]; then
+    if command -v jq >/dev/null 2>&1; then
+      if [ "$DRY_RUN" = true ]; then
+        echo "  [dry-run] remove CK hook entries from $HOOKS_JSON"
+      else
+        jq '
+          .hooks = (.hooks // {}) |
+          .hooks.PreToolUse = [(.hooks.PreToolUse // [])[] |
+            .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-bash-guard|ck-read-guard|ck-search-guard") | not)] |
+            select((.hooks | length) > 0)
+          ] |
+          .hooks.PostToolUse = [(.hooks.PostToolUse // [])[] |
+            .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-scope-hint") | not)] |
+            select((.hooks | length) > 0)
+          ] |
+          .hooks.SessionStart = [(.hooks.SessionStart // [])[] |
+            .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-update-check") | not)] |
+            select((.hooks | length) > 0)
+          ] |
+          .hooks.Stop = [(.hooks.Stop // [])[] |
+            .hooks = [(.hooks // [])[]? | select((.command // "") | test("ck-postsession") | not)] |
+            select((.hooks | length) > 0)
+          ]
+        ' "$HOOKS_JSON" > "$HOOKS_JSON.tmp" && mv "$HOOKS_JSON.tmp" "$HOOKS_JSON"
+        ok "Removed CK hook entries from $HOOKS_JSON"
+      fi
+    else
+      echo "  WARNING: jq not found — CK entries in $HOOKS_JSON not removed."
+      echo "  Manually delete the ck-* hook entries (PreToolUse/PostToolUse/SessionStart/Stop)."
+    fi
+  fi
+  info ""
+fi
+
+# ── OpenCode (~/.config/opencode/) ────────────────────────────────────────────
+if [ "$DO_OPENCODE" = true ]; then
+  info "── OpenCode (~/.config/opencode/) ────────────────────────────────────────"
+  purge_ck_skills "$OPENCODE_HOME/skills"
+  rm_path "$OPENCODE_HOME/plugins/ck-guards.ts"
+  rm_path "$LEGACY_OPENCODE_HOME/plugin/ck-guards.ts"
+  rm_path "$OPENCODE_HOME/agents/explore.md"
+  rm_path "$OPENCODE_HOME/ck-code-search-protocol.md"
+  [ "$DRY_RUN" = true ] || ok "Skills, plugin, agent and protocol removed"
+
+  # Determine which OpenCode config file the installer wrote to.
+  OPENCODE_CFG=""
+  if [ -f "$OPENCODE_HOME/opencode.jsonc" ]; then
+    OPENCODE_CFG="$OPENCODE_HOME/opencode.jsonc"
+  elif [ -f "$OPENCODE_HOME/opencode.json" ]; then
+    OPENCODE_CFG="$OPENCODE_HOME/opencode.json"
+  fi
+
+  if [ -n "$OPENCODE_CFG" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo "  [dry-run] remove CK plugin + instructions entries from $OPENCODE_CFG"
+    elif [[ "$OPENCODE_CFG" == *.jsonc ]]; then
+      # JSONC path: edit in-place so comments are preserved.
+      python3 - "$OPENCODE_CFG" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, "r", encoding="utf-8").read()
+
+def remove_array_entry(src: str, key: str, value: str) -> str:
+    # Match the first `"key": [ ... ]` block.
+    pattern = rf'("{re.escape(key)}"\s*:\s*\[)(.*?)(\])'
+    m = re.search(pattern, src, flags=re.S)
+    if not m:
+        return src
+    head, body, close = m.group(1), m.group(2), m.group(3)
+    # Drop the element `"value"` plus a trailing or leading comma.
+    quoted = re.escape(value)
+    new_body = re.sub(rf'\s*"{quoted}"\s*,?', '', body, count=1)
+    # If that left a dangling leading comma (we removed a middle/last item),
+    # clean up `, ]` and `[ ,` artifacts.
+    new_body = re.sub(r',(\s*)$', r'\1', new_body)
+    new_body = re.sub(r'^(\s*),', r'\1', new_body)
+    return src[:m.start()] + head + new_body + close + src[m.end():]
+
+updated = remove_array_entry(text, "plugin", "./plugins/ck-guards.ts")
+updated = remove_array_entry(updated, "instructions", "./ck-code-search-protocol.md")
+if updated != text:
+    open(path, "w", encoding="utf-8").write(updated)
+PY
+      ok "Removed CK plugin and instructions entries from $OPENCODE_CFG"
+    elif command -v jq >/dev/null 2>&1; then
+      jq '
+        .plugin = [(.plugin // [])[] | select(. != "./plugins/ck-guards.ts")] |
+        .instructions = [(.instructions // [])[] | select(. != "./ck-code-search-protocol.md")]
+      ' "$OPENCODE_CFG" > "$OPENCODE_CFG.tmp" && mv "$OPENCODE_CFG.tmp" "$OPENCODE_CFG"
+      ok "Removed CK plugin and instructions entries from $OPENCODE_CFG"
+    else
+      echo "  WARNING: neither python3 nor jq found — CK entries in $OPENCODE_CFG not removed."
+      echo '  Manually delete "./plugins/ck-guards.ts" from "plugin" and "./ck-code-search-protocol.md" from "instructions".'
+    fi
+  fi
+  info ""
+fi
+
+# ── Generic Agent Skills (~/.agents/skills/) ──────────────────────────────────
+if [ "$DO_AGENTS" = true ]; then
+  info "── Agent Skills (~/.agents/skills/) ──────────────────────────────────────"
+  purge_ck_skills "$AGENTS_HOME/skills"
+  [ "$DRY_RUN" = true ] || ok "Skills removed"
+  info ""
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+if [ "$DRY_RUN" = true ]; then
+  info "Dry run complete — no changes were made."
+else
+  info "Context King uninstalled globally."
+fi
+info ""
+info "Per-repo files created by 'ck init' are NOT removed (they may be git-tracked)."
+info "To remove them from a repository:"
+info "  rm -rf .ck-index .ck-knowledge .ck.json"
+info "Also remove .ck-index/ from that repo's .gitignore if you added it."

--- a/scripts/uninstall-global.sh
+++ b/scripts/uninstall-global.sh
@@ -9,6 +9,12 @@
 # client's config. Per-repo files created by `ck init` (.ck.json, .ck-knowledge/,
 # .ck-index/) are NOT touched — they may be git-tracked; remove them manually.
 #
+# ── One-liner uninstall ─────────────────────────────────────────────────────────
+#   curl -fsSL https://github.com/Fredrik-C/ContextKing/releases/latest/download/uninstall-global.sh | bash
+#
+# ── Download and run (to pass flags) ────────────────────────────────────────────
+#   curl -fsSL .../uninstall-global.sh -o uninstall-global.sh && bash uninstall-global.sh --dry-run
+#
 # ── Run from a cloned repo ──────────────────────────────────────────────────────
 #   bash scripts/uninstall-global.sh
 #
@@ -79,7 +85,7 @@ while [ "$#" -gt 0 ]; do
     --no-opencode)  DO_OPENCODE=false; shift ;;
     --no-agents)    DO_AGENTS=false;   shift ;;
     -h|--help)
-      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -34
+      grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -40
       exit 0 ;;
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac

--- a/scripts/uninstall-global.sh
+++ b/scripts/uninstall-global.sh
@@ -222,14 +222,18 @@ if [ "$DO_CODEX" = true ]; then
     fi
   fi
 
-  # Remove the project_doc_fallback_filenames line from config.toml.
+  # Remove the project_doc_fallback_filenames line from config.toml. Match the
+  # exact literal the installer writes (symmetric with the install side) so we
+  # never touch a user-owned value the installer deliberately skipped, and never
+  # half-delete a multi-line TOML array.
   CODEX_CONFIG="$CODEX_HOME/config.toml"
-  if [ -f "$CODEX_CONFIG" ] && grep -qF 'project_doc_fallback_filenames' "$CODEX_CONFIG" 2>/dev/null; then
+  CODEX_FALLBACK_LINE='project_doc_fallback_filenames = ["ck-code-search-protocol.md"]'
+  if [ -f "$CODEX_CONFIG" ] && grep -qxF "$CODEX_FALLBACK_LINE" "$CODEX_CONFIG" 2>/dev/null; then
     if [ "$DRY_RUN" = true ]; then
       echo "  [dry-run] remove project_doc_fallback_filenames from $CODEX_CONFIG"
     else
       tmp="$(mktemp)"
-      grep -v 'project_doc_fallback_filenames' "$CODEX_CONFIG" > "$tmp" || true
+      grep -vxF "$CODEX_FALLBACK_LINE" "$CODEX_CONFIG" > "$tmp" || true
       mv "$tmp" "$CODEX_CONFIG"
       ok "Removed project_doc_fallback_filenames from $CODEX_CONFIG"
     fi


### PR DESCRIPTION
Mirror `install-global.{sh,ps1}` to reverse a global install:
- remove the ~/.ck tree (binary + model)
- strip ~/.ck/bin from PATH
- delete CK skills/hooks/rules across ~/.claude, ~/.codex,
~/.config/opencode, and ~/.agents
- remove CK entries from each client's config (settings.json, hooks.json, opencode.json(c), Codex AGENTS.md / config.toml) — leaving all other content intact.

Adds a `--dry-run` / `-DryRun` preview flag and mirrors the installer's skip/home-override flags.

Per-repo artifacts from `ck init` are left untouched (a manual-cleanup note is printed). 

Documents the scripts in a new README "Uninstall" section.

Also added the script to release assets and to the release notes.